### PR TITLE
Chore: Allow per project addon version

### DIFF
--- a/package.py
+++ b/package.py
@@ -2,8 +2,8 @@ name = "wrap"
 title = "Wrap"
 version = "0.0.3-dev.1"
 app_host_name = "wrap"
-
 client_dir = "ayon_wrap"
+project_can_override_addon_version = True
 
 plugin_for = ["ayon_server"]
 build_command = ""


### PR DESCRIPTION
## Changelog Description
Addon can be used in per-project bundles.

## Additional informatio
I didn't find any conflicts that would not allow to use the addon in per project bundles.

## Testing notes:
1. Addon can be used in per-project bundles.
